### PR TITLE
removed single-quotes from logback.xml template

### DIFF
--- a/skeleton/grails-app/conf/logback.xml
+++ b/skeleton/grails-app/conf/logback.xml
@@ -7,7 +7,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
It seems the single-quotes were copied from logback.groovy, but they are not necessary.

Before the single-quotes were printed to the console, which looked weird:
```
'2022-01-26 14:40:38.140  WARN --- [  restartedMain] org.grails.config.NavigableMap           : Accessing config key '[plugins]' through dot notation is deprecated, and it will be removed in a future release. Use 'config.getProperty(key, targetClass)' instead.
''2022-01-26 14:40:43.486  WARN --- [  restartedMain] org.grails.config.NavigableMap           : Accessing config key '[plugins, springsecurity]' through dot notation is deprecated, and it will be removed in a future release. Use 'config.getProperty(key, targetClass)' instead.
'
```